### PR TITLE
Revamp popup layout and rendering

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -5,24 +5,63 @@
 
 body {
   margin: 0;
-  padding: 1rem;
   min-width: 320px;
-  background: var(--popup-background, #f4f6fb);
+  background: #f4f6fb;
   color: #1f2933;
 }
 
-header {
-  text-align: center;
-  margin-bottom: 1rem;
-}
-
-main {
+.popup {
+  padding: 1rem 1.25rem 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
-.timezone-list {
+.popup__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.popup__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.popup__settings {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 1.2rem;
+  color: inherit;
+}
+
+.popup__settings:hover,
+.popup__settings:focus {
+  background: rgba(37, 99, 235, 0.1);
+  outline: none;
+}
+
+.popup__section-title {
+  margin: 0 0 0.25rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #546a7b;
+}
+
+.current-time {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.people-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -31,46 +70,80 @@ main {
   gap: 0.75rem;
 }
 
-.timezone-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.75rem;
-  border-radius: 0.5rem;
+.people-list__empty {
+  padding: 1rem;
+  border-radius: 0.75rem;
   background: #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
+  font-size: 0.9rem;
+  color: #6b7a89;
 }
 
-.timezone-details {
+.person {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
 }
 
-.field {
+.person__header {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  margin-bottom: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-button {
-  cursor: pointer;
-  border: none;
-  border-radius: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: #2563eb;
-  color: #ffffff;
+.person__name {
+  margin: 0;
+  font-size: 0.95rem;
   font-weight: 600;
 }
 
-button.secondary {
-  background: transparent;
-  border: 1px solid #2563eb;
-  color: #2563eb;
+.person__time {
+  font-size: 1.2rem;
+  font-weight: 700;
 }
 
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.person__meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #6b7a89;
+}
+
+.person__timezone {
+  font-variant-numeric: tabular-nums;
+}
+
+.person__delta {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #111827;
+    color: #f9fafb;
+  }
+
+  .popup__section-title {
+    color: #94a3b8;
+  }
+
+  .people-list__empty,
+  .person {
+    background: #1f2937;
+    box-shadow: none;
+  }
+
+  .people-list__empty {
+    color: #94a3b8;
+  }
+
+  .person__meta {
+    color: #9ca3af;
+  }
 }

--- a/popup.html
+++ b/popup.html
@@ -7,29 +7,22 @@
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
-    <header>
-      <h1>Teams Time</h1>
-    </header>
-    <main>
-      <section aria-labelledby="team-timezones-heading">
-        <h2 id="team-timezones-heading">Team time zones</h2>
-        <ul id="timezone-list" class="timezone-list" aria-live="polite"></ul>
+    <div class="popup">
+      <header class="popup__header">
+        <h1 class="popup__title">Teams Time</h1>
+        <a class="popup__settings" href="options.html" title="Open settings" aria-label="Open settings">
+          <span aria-hidden="true">⚙️</span>
+        </a>
+      </header>
+      <section class="popup__current" aria-live="polite">
+        <h2 class="popup__section-title">Current time</h2>
+        <p id="current-time" class="current-time" role="status"></p>
       </section>
-      <section aria-labelledby="quick-add-heading">
-        <h2 id="quick-add-heading">Quick add</h2>
-        <form id="quick-add-form">
-          <div class="field">
-            <label for="quick-name">Name</label>
-            <input type="text" id="quick-name" name="name" required />
-          </div>
-          <div class="field">
-            <label for="quick-timezone">Time zone</label>
-            <select id="quick-timezone" name="timezone"></select>
-          </div>
-          <button type="submit">Add</button>
-        </form>
+      <section class="popup__people" aria-labelledby="people-heading">
+        <h2 id="people-heading" class="popup__section-title">Team</h2>
+        <ul id="people-list" class="people-list" aria-live="polite"></ul>
       </section>
-    </main>
+    </div>
     <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,75 +1,153 @@
-import {
-  STORAGE_KEYS,
-  getStoredValue,
-  setStoredValue,
-  upsertMember,
-  loadTimezoneOptions
-} from './util.js';
+import { getStoredValue, fmtTime, dayDelta, timeValue, escapeHtml } from './util.js';
 
-const timezoneList = document.getElementById('timezone-list');
-const quickAddForm = document.getElementById('quick-add-form');
-const quickNameField = document.getElementById('quick-name');
-const quickTimezoneField = document.getElementById('quick-timezone');
+const DEFAULT_PEOPLE = [];
+const DEFAULT_SETTINGS = {
+  sortMode: 'time',
+  baseTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+};
 
-function renderTeamMembers(members) {
-  timezoneList.innerHTML = '';
-  if (!members.length) {
-    const emptyState = document.createElement('li');
-    emptyState.className = 'timezone-item';
-    emptyState.textContent = 'Add teammates to see their current time.';
-    timezoneList.append(emptyState);
+const currentTimeElement = document.getElementById('current-time');
+const peopleListElement = document.getElementById('people-list');
+
+let state = {
+  people: DEFAULT_PEOPLE,
+  settings: DEFAULT_SETTINGS
+};
+let renderTimerId = null;
+
+function normalizePeople(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => ({
+      name: entry?.name ?? '',
+      timezone: entry?.timezone ?? ''
+    }))
+    .filter((entry) => entry.name && entry.timezone);
+}
+
+function normalizeSettings(value) {
+  const normalized = { ...DEFAULT_SETTINGS };
+  if (!value || typeof value !== 'object') {
+    return normalized;
+  }
+  if (typeof value.sortMode === 'string') {
+    const lower = value.sortMode.toLowerCase();
+    if (lower === 'name' || lower === 'time') {
+      normalized.sortMode = lower;
+    }
+  }
+  const suppliedBase =
+    value.baseTimeZone || value.defaultTimezone || value.timezone || value.referenceTimezone;
+  if (typeof suppliedBase === 'string' && suppliedBase) {
+    normalized.baseTimeZone = suppliedBase;
+  }
+  return normalized;
+}
+
+function describeDayDelta(delta) {
+  if (delta === 0) {
+    return 'Today';
+  }
+  if (delta === 1) {
+    return 'Tomorrow';
+  }
+  if (delta === -1) {
+    return 'Yesterday';
+  }
+  if (delta > 1) {
+    return `${delta} days ahead`;
+  }
+  return `${Math.abs(delta)} days behind`;
+}
+
+function sortPeople(people, sortMode, now) {
+  const sorted = [...people];
+  if (sortMode === 'name') {
+    return sorted.sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+  }
+  return sorted.sort((a, b) => {
+    const timeComparison = timeValue(now, a.timezone).localeCompare(
+      timeValue(now, b.timezone)
+    );
+    if (timeComparison !== 0) {
+      return timeComparison;
+    }
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+}
+
+function renderCurrentTime(now, baseTimeZone) {
+  const currentTime = fmtTime(now, baseTimeZone);
+  const timezoneLabel = baseTimeZone || 'Local time';
+  currentTimeElement.innerHTML = `${escapeHtml(currentTime)} • ${escapeHtml(timezoneLabel)}`;
+}
+
+function renderPeople(now, baseTimeZone, sortMode) {
+  peopleListElement.innerHTML = '';
+  if (!state.people.length) {
+    const empty = document.createElement('li');
+    empty.className = 'people-list__empty';
+    empty.textContent = 'Add teammates from the options page to see their local time.';
+    peopleListElement.append(empty);
     return;
   }
 
-  for (const member of members) {
+  const sorted = sortPeople(state.people, sortMode, now);
+  for (const person of sorted) {
+    const delta = dayDelta(now, person.timezone, baseTimeZone);
     const item = document.createElement('li');
-    item.className = 'timezone-item';
-
-    const info = document.createElement('div');
-    info.className = 'timezone-details';
-    const name = document.createElement('strong');
-    name.textContent = member.name;
-    const timezone = document.createElement('span');
-    timezone.textContent = member.timezone;
-    info.append(name, timezone);
-
-    const removeButton = document.createElement('button');
-    removeButton.type = 'button';
-    removeButton.textContent = 'Remove';
-    removeButton.className = 'secondary';
-    removeButton.addEventListener('click', async () => {
-      const filtered = members.filter((entry) => entry.id !== member.id);
-      await setStoredValue(STORAGE_KEYS.teamMembers, filtered);
-      renderTeamMembers(filtered);
-    });
-
-    item.append(info, removeButton);
-    timezoneList.append(item);
+    item.className = 'person';
+    item.innerHTML = `
+      <div class="person__header">
+        <h3 class="person__name">${escapeHtml(person.name)}</h3>
+        <span class="person__time">${escapeHtml(fmtTime(now, person.timezone))}</span>
+      </div>
+      <div class="person__meta">
+        <span class="person__delta">${escapeHtml(describeDayDelta(delta))}</span>
+        <span class="person__timezone">${escapeHtml(person.timezone)}</span>
+      </div>
+    `;
+    peopleListElement.append(item);
   }
 }
 
-async function handleQuickAdd(event) {
-  event.preventDefault();
-  const formData = new FormData(quickAddForm);
-  const name = formData.get('name');
-  const timezone = formData.get('timezone');
-  if (!name || !timezone) {
-    return;
+function render() {
+  const now = new Date();
+  const baseTimeZone = state.settings.baseTimeZone || DEFAULT_SETTINGS.baseTimeZone;
+  const sortMode = state.settings.sortMode || DEFAULT_SETTINGS.sortMode;
+  renderCurrentTime(now, baseTimeZone);
+  renderPeople(now, baseTimeZone, sortMode);
+}
+
+function startRenderTimer() {
+  if (renderTimerId !== null) {
+    clearInterval(renderTimerId);
   }
-
-  const members = await getStoredValue(STORAGE_KEYS.teamMembers, []);
-  const updatedMembers = upsertMember(members, { name, timezone });
-  await setStoredValue(STORAGE_KEYS.teamMembers, updatedMembers);
-  renderTeamMembers(updatedMembers);
-  quickAddForm.reset();
-  quickNameField.focus();
+  renderTimerId = setInterval(render, 60000);
 }
 
-async function init() {
-  await loadTimezoneOptions(quickTimezoneField);
-  const members = await getStoredValue(STORAGE_KEYS.teamMembers, []);
-  renderTeamMembers(members);
-  quickAddForm.addEventListener('submit', handleQuickAdd);
+async function hydrate() {
+  const [storedPeople, storedSettings] = await Promise.all([
+    getStoredValue('people', []),
+    getStoredValue('settings', {})
+  ]);
+  state = {
+    people: normalizePeople(storedPeople),
+    settings: normalizeSettings(storedSettings)
+  };
+  render();
+  startRenderTimer();
 }
 
-document.addEventListener('DOMContentLoaded', init);
+window.addEventListener('unload', () => {
+  if (renderTimerId !== null) {
+    clearInterval(renderTimerId);
+    renderTimerId = null;
+  }
+});
+
+document.addEventListener('DOMContentLoaded', hydrate);


### PR DESCRIPTION
## Summary
- rebuild the popup markup to match the planned layout with header, current time, and team list containers
- refresh the popup styling to align with the new structure and visual treatment
- load people/settings from synced storage, render sorted team times with escaped HTML, day deltas, and periodic refreshes

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d853592b14832882723f6e1e5f52ef