### PR TITLE
Refine timezone data source

### DIFF
--- a/options.js
+++ b/options.js
@@ -96,11 +96,9 @@ function populateTimezoneDatalist() {
   timezoneList.innerHTML = '';
   for (const zone of timezones) {
     const option = document.createElement('option');
-    option.value = zone.value;
-    option.textContent = zone.label;
-    if (zone.label) {
-      option.label = zone.label;
-    }
+    option.value = zone;
+    option.textContent = zone;
+    option.label = zone;
     timezoneList.append(option);
   }
 }

--- a/timezones.json
+++ b/timezones.json
@@ -1,12 +1,12 @@
 [
-  { "label": "UTC", "value": "UTC" },
-  { "label": "Pacific Time (US & Canada)", "value": "America/Los_Angeles" },
-  { "label": "Mountain Time (US & Canada)", "value": "America/Denver" },
-  { "label": "Central Time (US & Canada)", "value": "America/Chicago" },
-  { "label": "Eastern Time (US & Canada)", "value": "America/New_York" },
-  { "label": "United Kingdom", "value": "Europe/London" },
-  { "label": "Central Europe", "value": "Europe/Berlin" },
-  { "label": "India Standard Time", "value": "Asia/Kolkata" },
-  { "label": "Japan Standard Time", "value": "Asia/Tokyo" },
-  { "label": "Australia Eastern Time", "value": "Australia/Sydney" }
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Kolkata",
+  "Asia/Tokyo",
+  "Australia/Sydney"
 ]


### PR DESCRIPTION
## Summary
- convert `timezones.json` to a JSON string array of key global zones
- update the options page to populate the timezone datalist using the imported strings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d855b3b4d48328b09b2bd6133c7ff4