### PR TITLE
Expand options modal width and adjust card spacing

### DIFF
--- a/options.css
+++ b/options.css
@@ -11,7 +11,8 @@
 body {
   margin: 0 auto;
   padding: 2rem 1.5rem 3rem;
-  max-width: 720px;
+  max-width: 960px;
+  width: min(100%, 960px);
 }
 
 header {
@@ -174,5 +175,15 @@ button:focus-visible {
   .person-actions {
     display: flex;
     justify-content: flex-end;
+  }
+}
+
+@media (min-width: 900px) {
+  main {
+    gap: 2.5rem;
+  }
+
+  .card {
+    padding: 2.25rem 2.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- raise the options layout width cap to 960px with a responsive min() width
- add a large-screen spacing tweak so cards and sections breathe at wider breakpoints

## Testing
- Manual: opened options.html locally to verify the wider layout without overflow

------
https://chatgpt.com/codex/tasks/task_e_68d858daa2d48328887abed100eff224