### PR TITLE
Align popup and options styling with shared palette

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,7 +1,17 @@
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #0f172a;
-  background-color: #f8fafc;
+  --tt-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --tt-color-background: #f4f6fb;
+  --tt-color-text: #1f2933;
+  --tt-color-muted-text: #6b7a89;
+  --tt-color-card: #ffffff;
+  --tt-color-card-muted: #f1f5f9;
+  --tt-color-border: #cbd5f5;
+  --tt-color-accent: #2563eb;
+  --tt-color-accent-strong: #1d4ed8;
+  --tt-color-accent-contrast: #ffffff;
+  font-family: var(--tt-font-family);
+  color: var(--tt-color-text);
+  background-color: var(--tt-color-background);
 }
 
 * {
@@ -13,6 +23,8 @@ body {
   padding: 2rem 1.5rem 3rem;
   max-width: 960px;
   width: min(100%, 960px);
+  background: var(--tt-color-background);
+  color: var(--tt-color-text);
 }
 
 header {
@@ -31,7 +43,7 @@ main {
 }
 
 .card {
-  background: #ffffff;
+  background: var(--tt-color-card);
   border-radius: 0.75rem;
   padding: 1.75rem;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
@@ -48,7 +60,7 @@ main {
 .field > span,
 .field > label {
   font-size: 0.95rem;
-  color: #334155;
+  color: var(--tt-color-text);
 }
 
 input,
@@ -61,17 +73,17 @@ input,
 select {
   padding: 0.65rem 0.75rem;
   border-radius: 0.5rem;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
-  color: inherit;
+  border: 1px solid var(--tt-color-border);
+  background: var(--tt-color-card);
+  color: var(--tt-color-text);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 input:focus,
 select:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+  border-color: var(--tt-color-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
 }
 
 button {
@@ -79,16 +91,18 @@ button {
   border: none;
   border-radius: 0.5rem;
   padding: 0.65rem 1.2rem;
-  background: #0f172a;
-  color: #ffffff;
+  background: var(--tt-color-accent);
+  color: var(--tt-color-accent-contrast);
   font-weight: 600;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
 button:hover,
 button:focus-visible {
+  background: var(--tt-color-accent-strong);
   transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.25);
+  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.28);
+  outline: none;
 }
 
 .section-header {
@@ -100,7 +114,7 @@ button:focus-visible {
 
 .section-subtitle {
   margin: 0;
-  color: #475569;
+  color: var(--tt-color-muted-text);
   font-size: 0.95rem;
 }
 
@@ -117,7 +131,8 @@ button:focus-visible {
   gap: 1rem;
   padding: 0.9rem 1.2rem;
   border-radius: 0.65rem;
-  background: #e2e8f0;
+  background: var(--tt-color-card);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 .person-details {
@@ -137,28 +152,37 @@ button:focus-visible {
 
 .person-note {
   margin: 0;
-  color: #475569;
+  color: var(--tt-color-muted-text);
   font-size: 0.9rem;
 }
 
 .person-timezone {
   margin: 0;
   font-size: 0.85rem;
-  color: #1e293b;
+  color: var(--tt-color-text);
 }
 
 .person-actions button {
   background: transparent;
-  border: 1px solid #0f172a;
-  color: #0f172a;
+  border: 1px solid var(--tt-color-accent);
+  color: var(--tt-color-accent);
   padding: 0.45rem 0.9rem;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.person-actions button:hover,
+.person-actions button:focus-visible {
+  background: var(--tt-color-accent);
+  color: var(--tt-color-accent-contrast);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.24);
+  outline: none;
 }
 
 .people-list[role='list'] .empty-message {
   text-align: center;
   padding: 1.2rem 0;
-  color: #475569;
-  background: #f1f5f9;
+  color: var(--tt-color-muted-text);
+  background: var(--tt-color-card-muted);
   border-radius: 0.65rem;
 }
 

--- a/popup.css
+++ b/popup.css
@@ -1,13 +1,20 @@
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --tt-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --tt-color-background: #f4f6fb;
+  --tt-color-text: #1f2933;
+  --tt-color-card: #ffffff;
+  --tt-color-muted-text: #6b7a89;
+  --tt-color-accent: #2563eb;
+  --tt-color-accent-soft: rgba(37, 99, 235, 0.1);
+  font-family: var(--tt-font-family);
   color-scheme: light dark;
 }
 
 body {
   margin: 0;
   min-width: 320px;
-  background: #f4f6fb;
-  color: #1f2933;
+  background: var(--tt-color-background);
+  color: var(--tt-color-text);
 }
 
 .popup {
@@ -43,7 +50,7 @@ body {
 
 .popup__settings:hover,
 .popup__settings:focus {
-  background: rgba(37, 99, 235, 0.1);
+  background: var(--tt-color-accent-soft);
   outline: none;
 }
 
@@ -52,7 +59,7 @@ body {
   font-size: 0.8rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #546a7b;
+  color: var(--tt-color-muted-text);
 }
 
 .current-time {
@@ -73,10 +80,10 @@ body {
 .people-list__empty {
   padding: 1rem;
   border-radius: 0.75rem;
-  background: #ffffff;
+  background: var(--tt-color-card);
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
   font-size: 0.9rem;
-  color: #6b7a89;
+  color: var(--tt-color-muted-text);
 }
 
 .person {
@@ -85,7 +92,7 @@ body {
   gap: 0.25rem;
   padding: 0.85rem 1rem;
   border-radius: 0.75rem;
-  background: #ffffff;
+  background: var(--tt-color-card);
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
 }
 
@@ -111,7 +118,7 @@ body {
   display: flex;
   gap: 0.5rem;
   font-size: 0.8rem;
-  color: #6b7a89;
+  color: var(--tt-color-muted-text);
 }
 
 .person__timezone {
@@ -124,9 +131,13 @@ body {
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
-    background: #111827;
-    color: #f9fafb;
+  :root {
+    --tt-color-background: #111827;
+    --tt-color-text: #f9fafb;
+    --tt-color-card: #1f2937;
+    --tt-color-muted-text: #9ca3af;
+    --tt-color-accent: #60a5fa;
+    --tt-color-accent-soft: rgba(96, 165, 250, 0.18);
   }
 
   .popup__section-title {
@@ -135,15 +146,6 @@ body {
 
   .people-list__empty,
   .person {
-    background: #1f2937;
     box-shadow: none;
-  }
-
-  .people-list__empty {
-    color: #94a3b8;
-  }
-
-  .person__meta {
-    color: #9ca3af;
   }
 }


### PR DESCRIPTION
## Summary
- define shared typography and color custom properties for the popup, with dark theme overrides
- adopt the shared palette in the options view for body, cards, inputs, and buttons
- refresh options controls hover and focus states to match popup treatments while preserving contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8596fb13083289e24d16f21862b1e