### PR TITLE
Open options page in new tab from popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -10,9 +10,15 @@
     <div class="popup">
       <header class="popup__header">
         <h1 class="popup__title">Teams Time</h1>
-        <a class="popup__settings" href="options.html" title="Open settings" aria-label="Open settings">
+        <button
+          id="open-settings"
+          class="popup__settings"
+          type="button"
+          title="Open settings"
+          aria-label="Open settings"
+        >
           <span aria-hidden="true">⚙️</span>
-        </a>
+        </button>
       </header>
       <section class="popup__current" aria-live="polite">
         <h2 class="popup__section-title">Current time</h2>

--- a/popup.js
+++ b/popup.js
@@ -8,6 +8,7 @@ const DEFAULT_SETTINGS = {
 
 const currentTimeElement = document.getElementById('current-time');
 const peopleListElement = document.getElementById('people-list');
+const settingsButton = document.getElementById('open-settings');
 
 let state = {
   people: DEFAULT_PEOPLE,
@@ -151,3 +152,14 @@ window.addEventListener('unload', () => {
 });
 
 document.addEventListener('DOMContentLoaded', hydrate);
+
+if (settingsButton) {
+  settingsButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (chrome.runtime.openOptionsPage) {
+      chrome.runtime.openOptionsPage();
+    } else {
+      window.open(chrome.runtime.getURL('options.html'), '_blank');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- give the settings control in the popup a dedicated button element
- open the options page with chrome.runtime.openOptionsPage when possible, falling back to window.open

## Testing
- not run (extension behavior verified manually in Chrome per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d85c3f021c8328a9370b81518a9a8f