### PR TITLE
Add Alexandria timezone alias

### DIFF
--- a/timezone-aliases.js
+++ b/timezone-aliases.js
@@ -1,4 +1,6 @@
 const timezoneAliases = {
+  'Alexandria Egypt': 'Africa/Cairo',
+  Alexandria: 'Africa/Cairo',
   Belgium: 'Europe/Brussels',
   Bishkek: 'Asia/Bishkek',
   Uzbekistan: 'Asia/Tashkent'


### PR DESCRIPTION
## Summary
- add Alexandria aliases to map to the canonical Africa/Cairo timezone

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8662c9318832891b3d230ed843ccd