### PR TITLE
Add generated aliases for America time zones

### DIFF
--- a/timezone-aliases.js
+++ b/timezone-aliases.js
@@ -1,9 +1,49 @@
-const timezoneAliases = {
+import timezones from './timezones-data.js';
+
+const manualAliases = {
   'Alexandria Egypt': 'Africa/Cairo',
   Alexandria: 'Africa/Cairo',
   Belgium: 'Europe/Brussels',
   Bishkek: 'Asia/Bishkek',
   Uzbekistan: 'Asia/Tashkent'
+};
+
+function toFriendlySegment(segment) {
+  return segment.replace(/_/g, ' ');
+}
+
+const americaAliases = {};
+
+for (const zone of timezones) {
+  if (!zone.startsWith('America/')) {
+    continue;
+  }
+
+  const segments = zone.split('/').slice(1);
+  if (!segments.length) {
+    continue;
+  }
+
+  const friendlySegments = segments.map(toFriendlySegment);
+  const fullAlias = friendlySegments.join(', ');
+  const primaryAlias = friendlySegments[friendlySegments.length - 1];
+
+  if (fullAlias && !americaAliases[fullAlias] && !manualAliases[fullAlias]) {
+    americaAliases[fullAlias] = zone;
+  }
+
+  if (
+    primaryAlias &&
+    !americaAliases[primaryAlias] &&
+    !manualAliases[primaryAlias]
+  ) {
+    americaAliases[primaryAlias] = zone;
+  }
+}
+
+const timezoneAliases = {
+  ...americaAliases,
+  ...manualAliases
 };
 
 export default timezoneAliases;


### PR DESCRIPTION
## Summary
- generate friendly aliases for every America/* time zone using the canonical dataset
- retain manual alias overrides for previously requested names like Alexandria and Belgium

## Testing
- node -e "import('./timezone-aliases.js').then(m => { console.log(m.default['Los Angeles']); console.log(m.default['Indiana, Knox']); });"

------
https://chatgpt.com/codex/tasks/task_e_68d85b8965808328b1336cd7e1a2a9fb