### PR TITLE
Add viewer timeline row to options timeline view

### DIFF
--- a/options.css
+++ b/options.css
@@ -192,6 +192,21 @@ button:focus-visible {
   gap: 1.25rem;
 }
 
+.timeline-current-user {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.75rem;
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+}
+
+.timeline-current-user .timeline-row {
+  margin: 0;
+}
+
 .timeline-list .empty-message {
   text-align: center;
   padding: 1.2rem 0;
@@ -290,6 +305,20 @@ button:focus-visible {
   border-color: var(--tt-color-accent);
   background: rgba(37, 99, 235, 0.12);
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.timeline-row.is-viewer .timeline-person-name {
+  color: var(--tt-color-accent-strong);
+}
+
+.timeline-row.is-viewer .timeline-person-note {
+  color: var(--tt-color-accent-strong);
+}
+
+.timeline-row.is-viewer .timeline-hour.is-current {
+  border-color: var(--tt-color-accent-strong);
+  background: rgba(37, 99, 235, 0.2);
+  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.25);
 }
 
 .timeline-hour.is-day-change {

--- a/options.html
+++ b/options.html
@@ -74,6 +74,11 @@
             Compare everyone’s local hours across the next day.
           </p>
         </div>
+        <div
+          id="current-user-timeline"
+          class="timeline-current-user"
+          role="list"
+        ></div>
         <div id="timeline-list" class="timeline-list" role="list"></div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a dedicated timeline container in the options page for the viewer and style it distinctly
- detect the viewer's time zone, render their 24-hour timeline row before teammate rows, and reuse the existing markup for all rows
- refresh the viewer row on the existing interval so the sliding window stays current

## Testing
- not run (extension change)

------
https://chatgpt.com/codex/tasks/task_e_68d9ab0a92a08328905f5926af34137f