### PR TITLE
Sort teammates by time zone offset

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Teams Time is a Chrome extension that helps distributed teams quickly see the cu
 - Quick-add form in the popup for adding teammates on the fly.
 - Options page for managing the full roster and default preferences.
 - Options page timeline visualizes the next 24 hours for each teammate so you can coordinate at a glance.
+- Teammates are automatically sorted by their current UTC offset so nearby time zones stay grouped together.
 - Time zone data backed by a curated list in `timezones.json`.
 
 ## Development notes


### PR DESCRIPTION
## Summary
- add helpers that compute consistent UTC offsets so teammate lists can be sorted predictably
- render the options roster and timelines from the sorted data set and persist the normalized order
- document the automatic ordering in the README

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9abe2e8ac832890e2c20d9a3f3cc2