### PR TITLE
Refactor options timeline into unified scroller

### DIFF
--- a/options.css
+++ b/options.css
@@ -186,28 +186,27 @@ button:focus-visible {
   border-radius: 0.65rem;
 }
 
-.timeline-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+.timeline-scroller {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 0.75rem;
+  margin-top: 1rem;
 }
 
-.timeline-current-user {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: 0.75rem;
-  background: rgba(37, 99, 235, 0.12);
-  border: 1px solid rgba(37, 99, 235, 0.25);
+.timeline-rows {
+  --tt-hour-min-width: 2.75rem;
+  display: grid;
+  grid-template-columns: minmax(0, 220px) repeat(24, minmax(var(--tt-hour-min-width), 1fr));
+  column-gap: 0.35rem;
+  row-gap: 1.25rem;
+  width: max-content;
+  min-width: 100%;
+  align-items: flex-start;
+  padding-right: 0.5rem;
 }
 
-.timeline-current-user .timeline-row {
-  margin: 0;
-}
-
-.timeline-list .empty-message {
+.timeline-rows .empty-message {
+  grid-column: 1 / -1;
   text-align: center;
   padding: 1.2rem 0;
   color: var(--tt-color-muted-text);
@@ -216,16 +215,15 @@ button:focus-visible {
 }
 
 .timeline-row {
-  display: grid;
-  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
-  gap: 1.5rem;
-  align-items: flex-start;
+  display: contents;
 }
 
 .timeline-person {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  padding-right: 1.15rem;
+  grid-column: 1;
 }
 
 .timeline-person-name {
@@ -245,23 +243,8 @@ button:focus-visible {
 }
 
 .timeline-track {
-  --tt-hour-min-width: 2.75rem;
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(24, minmax(var(--tt-hour-min-width), 1fr));
-  gap: 0.35rem;
-  padding-bottom: 0.5rem;
-  overflow-x: auto;
-  scrollbar-width: thin;
-}
-
-.timeline-track::-webkit-scrollbar {
-  height: 6px;
-}
-
-.timeline-track::-webkit-scrollbar-thumb {
-  background: rgba(15, 23, 42, 0.2);
-  border-radius: 999px;
+  display: contents;
+  grid-column: 2 / -1;
 }
 
 .timeline-hour {
@@ -352,12 +335,7 @@ button:focus-visible {
     justify-content: flex-end;
   }
 
-  .timeline-row {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .timeline-track {
+  .timeline-rows {
     --tt-hour-min-width: 3.2rem;
   }
 }

--- a/options.html
+++ b/options.html
@@ -74,12 +74,9 @@
             Compare everyone’s local hours across the next day.
           </p>
         </div>
-        <div
-          id="current-user-timeline"
-          class="timeline-current-user"
-          role="list"
-        ></div>
-        <div id="timeline-list" class="timeline-list" role="list"></div>
+        <div class="timeline-scroller">
+          <div id="timeline-rows" class="timeline-rows" role="list"></div>
+        </div>
       </section>
     </main>
 

--- a/options.js
+++ b/options.js
@@ -112,8 +112,7 @@ const timezoneInput = document.getElementById('person-timezone');
 const peopleList = document.getElementById('people-list');
 const hourFormatSelect = document.getElementById('hour-format');
 const timelineSection = document.getElementById('timeline-section');
-const currentUserTimeline = document.getElementById('current-user-timeline');
-const timelineList = document.getElementById('timeline-list');
+const timelineRows = document.getElementById('timeline-rows');
 
 const STORAGE_KEYS = {
   people: 'people',
@@ -465,12 +464,11 @@ function createTimelineRow(entry, referenceDate) {
 }
 
 function renderTimelines(sortedEntries, referenceDate) {
-  if (!timelineList || !currentUserTimeline) {
+  if (!timelineRows) {
     return;
   }
 
-  currentUserTimeline.innerHTML = '';
-  timelineList.innerHTML = '';
+  timelineRows.innerHTML = '';
 
   const now = referenceDate instanceof Date ? referenceDate : new Date();
   const entries = Array.isArray(sortedEntries) ? sortedEntries : getSortedPeople(now);
@@ -487,14 +485,15 @@ function renderTimelines(sortedEntries, referenceDate) {
   );
 
   if (viewerRow) {
-    currentUserTimeline.append(viewerRow);
+    timelineRows.append(viewerRow);
   }
 
   if (!entries.length) {
     const message = document.createElement('div');
     message.className = 'empty-message';
     message.textContent = 'Timelines will appear after you add teammates.';
-    timelineList.append(message);
+    message.setAttribute('role', 'listitem');
+    timelineRows.append(message);
     return;
   }
 
@@ -509,7 +508,7 @@ function renderTimelines(sortedEntries, referenceDate) {
     );
 
     if (row) {
-      timelineList.append(row);
+      timelineRows.append(row);
     }
   }
 }
@@ -519,7 +518,7 @@ function startTimelineRefresh() {
     return;
   }
 
-  if (!timelineList || !currentUserTimeline) {
+  if (!timelineRows) {
     return;
   }
 
@@ -615,7 +614,7 @@ async function initialize() {
   hourFormatSelect.value = settings.hour12 ? '12' : '24';
   renderPeople(initializationReference, people);
 
-  if (timelineSection && timelineList && currentUserTimeline) {
+  if (timelineSection && timelineRows) {
     startTimelineRefresh();
   }
 }


### PR DESCRIPTION
## Summary
- wrap the teammate timeline markup in a single scrollable container
- convert the timeline rows to a shared 24-hour grid without per-row scrollbars
- update options.js to render the viewer and teammates into the unified list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9ae20fd24832892bf5bc5df5f4fde