### PR TITLE
Make timeline person column sticky

### DIFF
--- a/options.css
+++ b/options.css
@@ -222,8 +222,13 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding-right: 1.15rem;
+  padding-right: calc(1.15rem + 0.35rem);
+  margin-right: -0.35rem;
   grid-column: 1;
+  position: sticky;
+  left: 0;
+  background: var(--tt-color-card);
+  z-index: 2;
 }
 
 .timeline-person-name {


### PR DESCRIPTION
## Summary
- keep the person column visible by making it sticky with an aligned background
- tune the sticky column spacing so the grid layout stays consistent while scrolling

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68da74547af8832886c8fa6fdcabe2a9