### PR TITLE
Align options theme with popup styles

### DIFF
--- a/options.css
+++ b/options.css
@@ -2,16 +2,18 @@
   --tt-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --tt-color-background: #f4f6fb;
   --tt-color-text: #1f2933;
-  --tt-color-muted-text: #6b7a89;
   --tt-color-card: #ffffff;
   --tt-color-card-muted: #f1f5f9;
+  --tt-color-muted-text: #6b7a89;
   --tt-color-border: #cbd5f5;
   --tt-color-accent: #2563eb;
   --tt-color-accent-strong: #1d4ed8;
+  --tt-color-accent-soft: rgba(37, 99, 235, 0.1);
   --tt-color-accent-contrast: #ffffff;
   font-family: var(--tt-font-family);
   color: var(--tt-color-text);
   background-color: var(--tt-color-background);
+  color-scheme: light dark;
 }
 
 * {
@@ -46,7 +48,7 @@ main {
   background: var(--tt-color-card);
   border-radius: 0.75rem;
   padding: 1.75rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
 }
 
 .field {
@@ -83,7 +85,7 @@ input:focus,
 select:focus {
   outline: none;
   border-color: var(--tt-color-accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 0 0 3px var(--tt-color-accent-soft);
 }
 
 button {
@@ -101,7 +103,7 @@ button:hover,
 button:focus-visible {
   background: var(--tt-color-accent-strong);
   transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.28);
+  box-shadow: 0 10px 18px var(--tt-color-accent-soft);
   outline: none;
 }
 
@@ -132,7 +134,7 @@ button:focus-visible {
   padding: 0.9rem 1.2rem;
   border-radius: 0.65rem;
   background: var(--tt-color-card);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
 }
 
 .person-details {
@@ -174,7 +176,7 @@ button:focus-visible {
 .person-actions button:focus-visible {
   background: var(--tt-color-accent);
   color: var(--tt-color-accent-contrast);
-  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.24);
+  box-shadow: 0 8px 16px var(--tt-color-accent-soft);
   outline: none;
 }
 
@@ -291,8 +293,8 @@ button:focus-visible {
 
 .timeline-hour.is-current {
   border-color: var(--tt-color-accent);
-  background: rgba(37, 99, 235, 0.12);
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+  background: var(--tt-color-accent-soft);
+  box-shadow: 0 0 0 2px var(--tt-color-accent-soft);
 }
 
 .timeline-row.is-viewer .timeline-person-name {
@@ -305,8 +307,7 @@ button:focus-visible {
 
 .timeline-row.is-viewer .timeline-hour.is-current {
   border-color: var(--tt-color-accent-strong);
-  background: rgba(37, 99, 235, 0.2);
-  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.25);
+  box-shadow: 0 0 0 2px var(--tt-color-accent-soft);
 }
 
 .timeline-hour.is-day-change {
@@ -323,6 +324,47 @@ button:focus-visible {
   background: var(--tt-color-accent-strong);
   transform: translateX(-50%);
   border-radius: 999px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --tt-color-background: #111827;
+    --tt-color-text: #f9fafb;
+    --tt-color-card: #1f2937;
+    --tt-color-card-muted: #111827;
+    --tt-color-muted-text: #9ca3af;
+    --tt-color-border: #374151;
+    --tt-color-accent: #60a5fa;
+    --tt-color-accent-strong: #3b82f6;
+    --tt-color-accent-soft: rgba(96, 165, 250, 0.18);
+  }
+
+  body {
+    background: var(--tt-color-background);
+    color: var(--tt-color-text);
+  }
+
+  .card,
+  .person,
+  .timeline-hour {
+    box-shadow: none;
+  }
+
+  .people-list[role='list'] .empty-message,
+  .timeline-rows .empty-message {
+    background: var(--tt-color-card);
+    color: var(--tt-color-muted-text);
+  }
+
+  .person-actions button {
+    border-color: var(--tt-color-accent);
+    color: var(--tt-color-accent);
+  }
+
+  .person-actions button:hover,
+  .person-actions button:focus-visible {
+    box-shadow: none;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- mirror the popup root theme variables in the options stylesheet and enable `color-scheme`
- add `prefers-color-scheme: dark` overrides so the options UI follows the light and dark palettes
- reuse popup-aligned shadows and accent utilities for form, card, and timeline states

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da7739ff908328a0234c7be8a8a8d7