### PR TITLE
Respect popup hour format preference

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -3,7 +3,8 @@ import { getStoredValue, fmtTime, dayDelta, timeValue, escapeHtml } from './util
 const DEFAULT_PEOPLE = [];
 const DEFAULT_SETTINGS = {
   sortMode: 'time',
-  baseTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+  baseTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  hour12: true
 };
 
 const currentTimeElement = document.getElementById('current-time');
@@ -44,6 +45,9 @@ function normalizeSettings(value) {
   if (typeof suppliedBase === 'string' && suppliedBase) {
     normalized.baseTimeZone = suppliedBase;
   }
+  if (typeof value.hour12 === 'boolean') {
+    normalized.hour12 = value.hour12;
+  }
   return normalized;
 }
 
@@ -81,13 +85,13 @@ function sortPeople(people, sortMode, now) {
   });
 }
 
-function renderCurrentTime(now, baseTimeZone) {
-  const currentTime = fmtTime(now, baseTimeZone);
+function renderCurrentTime(now, baseTimeZone, hour12) {
+  const currentTime = fmtTime(now, baseTimeZone, { hour12 });
   const timezoneLabel = baseTimeZone || 'Local time';
   currentTimeElement.innerHTML = `${escapeHtml(currentTime)} • ${escapeHtml(timezoneLabel)}`;
 }
 
-function renderPeople(now, baseTimeZone, sortMode) {
+function renderPeople(now, baseTimeZone, sortMode, hour12) {
   peopleListElement.innerHTML = '';
   if (!state.people.length) {
     const empty = document.createElement('li');
@@ -105,7 +109,7 @@ function renderPeople(now, baseTimeZone, sortMode) {
     item.innerHTML = `
       <div class="person__header">
         <h3 class="person__name">${escapeHtml(person.name)}</h3>
-        <span class="person__time">${escapeHtml(fmtTime(now, person.timezone))}</span>
+        <span class="person__time">${escapeHtml(fmtTime(now, person.timezone, { hour12 }))}</span>
       </div>
       <div class="person__meta">
         <span class="person__delta">${escapeHtml(describeDayDelta(delta))}</span>
@@ -120,8 +124,10 @@ function render() {
   const now = new Date();
   const baseTimeZone = state.settings.baseTimeZone || DEFAULT_SETTINGS.baseTimeZone;
   const sortMode = state.settings.sortMode || DEFAULT_SETTINGS.sortMode;
-  renderCurrentTime(now, baseTimeZone);
-  renderPeople(now, baseTimeZone, sortMode);
+  const hour12 =
+    typeof state.settings.hour12 === 'boolean' ? state.settings.hour12 : DEFAULT_SETTINGS.hour12;
+  renderCurrentTime(now, baseTimeZone, hour12);
+  renderPeople(now, baseTimeZone, sortMode, hour12);
 }
 
 function startRenderTimer() {

--- a/util.js
+++ b/util.js
@@ -139,7 +139,8 @@ const formatterCache = new Map();
 
 function getFormatter(prefix, timeZone, options) {
   const zoneKey = timeZone ?? 'default';
-  const cacheKey = `${prefix}::${zoneKey}`;
+  const optionsKey = options ? JSON.stringify(options) : 'default';
+  const cacheKey = `${prefix}::${zoneKey}::${optionsKey}`;
   let formatter = formatterCache.get(cacheKey);
   if (!formatter) {
     const resolvedOptions = timeZone ? { ...options, timeZone } : { ...options };
@@ -182,11 +183,18 @@ function ymd(date, timeZone) {
   return { year, month, day };
 }
 
-export function fmtTime(date, timeZone) {
-  const formatter = getFormatter('time', timeZone, {
+export function fmtTime(date, timeZone, { hour12, hourCycle } = {}) {
+  const formatterOptions = {
     hour: 'numeric',
     minute: '2-digit'
-  });
+  };
+  if (typeof hour12 === 'boolean') {
+    formatterOptions.hour12 = hour12;
+  }
+  if (hourCycle) {
+    formatterOptions.hourCycle = hourCycle;
+  }
+  const formatter = getFormatter('time', timeZone, formatterOptions);
   const parts = formatter.formatToParts(date);
   return parts
     .filter((part) => part.type === 'hour' || part.type === 'minute' || part.type === 'dayPeriod' || part.type === 'literal')


### PR DESCRIPTION
## Summary
- default popup settings now include the hour format preference and retain user choices from storage
- render both the current time and teammate rows with the selected 12/24-hour mode
- extend fmtTime/formatter caching to respect hour format options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8f4ea3e8832882e7993d5b170b43