### PR TITLE
Add roster import and export controls

### DIFF
--- a/options.css
+++ b/options.css
@@ -150,6 +150,13 @@ button:focus-visible {
   margin-bottom: 1.25rem;
 }
 
+.section-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
 .section-subtitle {
   margin: 0;
   color: var(--tt-color-muted-text);
@@ -198,6 +205,21 @@ button:focus-visible {
   margin: 0;
   font-size: 0.85rem;
   color: var(--tt-color-text);
+}
+
+.status-message {
+  min-height: 1.25em;
+  margin: 0 0 1.25rem;
+  font-size: 0.9rem;
+  color: var(--tt-color-muted-text);
+}
+
+.status-message[data-status='success'] {
+  color: #047857;
+}
+
+.status-message[data-status='error'] {
+  color: #b91c1c;
 }
 
 .person-actions button {

--- a/options.html
+++ b/options.html
@@ -87,6 +87,23 @@
           <h2 id="people-heading">Teammates</h2>
           <p class="section-subtitle">Remove someone when they no longer need tracking.</p>
         </div>
+        <div class="section-actions" aria-label="Teammate roster actions">
+          <button type="button" id="people-export">Export roster</button>
+          <button type="button" id="people-import">Import roster</button>
+          <input
+            type="file"
+            id="people-import-input"
+            accept="application/json"
+            hidden
+            aria-hidden="true"
+          />
+        </div>
+        <p
+          id="people-feedback"
+          class="status-message"
+          role="status"
+          aria-live="polite"
+        ></p>
         <div id="people-list" class="people-list" role="list"></div>
       </section>
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,25 @@ Teams Time is a Chrome extension that helps distributed teams quickly see the cu
 - Teammates are automatically sorted by their current UTC offset so nearby time zones stay grouped together.
 - Time zone data backed by a curated list in `timezones.json`.
 
+## Share rosters between teammates
+
+The options page now includes **Export roster** and **Import roster** buttons in the Teammates card so groups can stay in sync:
+
+1. Click **Export roster** to download a JSON file that contains the current `people` array (each entry has `id`, `name`, optional `note`, and `timezone`). Share this file with another teammate or commit it to team docs.
+2. On another device or profile, open the options page and choose **Import roster**, then pick the shared JSON file. Valid entries are merged with the existing roster so no one is accidentally removed.
+3. To fully replace the current roster, wrap the exported data in an object before importing:
+
+   ```json
+   {
+     "mode": "replace",
+     "people": [
+       { "id": "abc", "name": "Ada", "note": "Engineering", "timezone": "Europe/London" }
+     ]
+   }
+   ```
+
+   The importer validates each entry’s ID, name, and time zone before saving. Any skipped entries are reported in the status message below the controls.
+
 ## Development notes
 
 - Extension metadata lives in `manifest.json` (Manifest V3).


### PR DESCRIPTION
## Summary
- add roster export and import controls to the options page with inline status messaging
- serialize teammates to JSON for downloads and validate imported rosters before merging or replacing stored data
- document the roster sharing workflow so teams understand how to exchange lists

## Testing
- Manual verification by loading options.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68dc0e0bf860832885595024961b2912