### PR TITLE
Add world basemap to timezone map

### DIFF
--- a/assets/world-outline.svg
+++ b/assets/world-outline.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400">
+  <defs>
+    <linearGradient id="worldWater" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#dbeafe" />
+      <stop offset="1" stop-color="#bfdbfe" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="400" fill="url(#worldWater)" />
+  <g fill="#bfdbfe" stroke="#60a5fa" stroke-width="3" stroke-linejoin="round">
+    <path d="M78 180l46-52 78-24 56 18 34-26 46 16 16 36-54 54-44-12-52 28-52-12-48 32-38-22z" />
+    <path d="M300 90l80-36 56 14 58-22 70 16 32 40-20 52-72 26-54-18-42 32-76-12-38-38z" />
+    <path d="M458 220l64-40 62-6 74 26 26 40-24 40-66 20-68-20-44-46z" />
+    <path d="M646 130l50-30 52 10 32 32-20 52-48 8-40-32-26-40z" />
+    <path d="M188 240l52 10 40 46-16 66-52 16-44-42 20-48z" />
+    <path d="M542 300l46-20 52 24 8 42-40 32-52-14-14-36z" />
+  </g>
+</svg>

--- a/options.css
+++ b/options.css
@@ -83,6 +83,8 @@ main {
   border: 1px solid var(--tt-color-border);
   background: var(--tt-color-card);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.02);
+  aspect-ratio: 2 / 1;
+  overflow: hidden;
 }
 
 .timezone-map {
@@ -103,8 +105,12 @@ main {
 
 .timezone-map-canvas {
   width: 100%;
-  height: auto;
-  max-height: 320px;
+  height: 100%;
+  max-height: none;
+}
+
+.timezone-map-basemap {
+  pointer-events: none;
 }
 
 .timezone-map-region {

--- a/options.js
+++ b/options.js
@@ -19,6 +19,9 @@ let cachedTimezoneGeoData = null;
 const timezoneMapRegionsByZone = new Map();
 let activeTimezoneMapRegion = null;
 const MAP_POINT_RADIUS = 4.5;
+const WORLD_BASEMAP_URL = runtimeChrome?.runtime?.getURL
+  ? runtimeChrome.runtime.getURL('assets/world-outline.svg')
+  : new URL('./assets/world-outline.svg', import.meta.url).toString();
 
 function getFallbackKey(key) {
   return `teams-time::${key}`;
@@ -734,6 +737,16 @@ function renderTimezoneMap(features) {
   svg.setAttribute('class', 'timezone-map-canvas');
   svg.setAttribute('role', 'group');
   svg.setAttribute('aria-label', 'Selectable time zones');
+
+  const basemap = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+  basemap.setAttribute('href', WORLD_BASEMAP_URL);
+  basemap.setAttribute('class', 'timezone-map-basemap');
+  basemap.setAttribute('x', '0');
+  basemap.setAttribute('y', '0');
+  basemap.setAttribute('width', String(width));
+  basemap.setAttribute('height', String(height));
+  basemap.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+  svg.append(basemap);
 
   for (const feature of features) {
     if (!feature || !feature.id) {


### PR DESCRIPTION
## Summary
- add a reusable world outline SVG asset for the options map
- render the new basemap layer before timezone regions so it appears behind the dots
- tune map sizing and pointer-event styles so the basemap scales correctly without blocking interactions

## Testing
- Manual QA in Playwright: opened options.html, verified basemap renders, clicked and keyboard-selected map zones to update the timezone input

------
https://chatgpt.com/codex/tasks/task_e_68dc28006654832895ce48cf66264009