### PR TITLE
Handle string timezone option data

### DIFF
--- a/util.js
+++ b/util.js
@@ -127,10 +127,38 @@ export async function loadTimezoneOptions(selectElement, { includeEmpty = false 
     emptyOption.textContent = 'Select a time zone';
     selectElement.append(emptyOption);
   }
+  // `fetchTimezones` currently returns a list of IANA zone IDs as strings. Normalize
+  // to handle that shape while remaining resilient if the data source ever returns
+  // objects instead (e.g. `{ value, label }`).
   for (const zone of zones) {
     const option = document.createElement('option');
-    option.value = zone.value;
-    option.textContent = zone.label;
+    if (typeof zone === 'string') {
+      option.value = zone;
+      option.textContent = zone;
+    } else if (zone && typeof zone === 'object') {
+      const value =
+        typeof zone.value === 'string'
+          ? zone.value
+          : typeof zone.id === 'string'
+          ? zone.id
+          : typeof zone.zoneId === 'string'
+          ? zone.zoneId
+          : '';
+      const label =
+        typeof zone.label === 'string'
+          ? zone.label
+          : typeof zone.name === 'string'
+          ? zone.name
+          : value;
+      option.value = value;
+      option.textContent = label;
+    } else {
+      option.value = '';
+      option.textContent = '';
+    }
+    if (!option.value) {
+      continue;
+    }
     selectElement.append(option);
   }
 }


### PR DESCRIPTION
## Summary
- normalize timezone option loading to treat string zone entries as both value and label
- add defensive handling and documentation for potential object-shaped timezone data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc53b43b5c8328bafd0f6140de0bc1