### PR TITLE
Validate popup base timezone settings

### DIFF
--- a/popup.test.mjs
+++ b/popup.test.mjs
@@ -1,0 +1,45 @@
+import { beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeSettings } from './popup.js';
+import { getStoredValue, setStoredValue } from './util.js';
+
+beforeEach(async () => {
+  await setStoredValue('settings', {});
+});
+
+test('normalizeSettings falls back to default timezone when stored zone is invalid', async () => {
+  const invalidZone = 'Not/AZone';
+  const normalized = normalizeSettings({ baseTimeZone: invalidZone, hour12: false });
+  await Promise.resolve();
+
+  const fallbackZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  assert.strictEqual(normalized.baseTimeZone, fallbackZone);
+  assert.strictEqual(normalized.hour12, false);
+
+  const stored = await getStoredValue('settings', {});
+  assert.ok(!('baseTimeZone' in stored));
+});
+
+test('normalizeSettings keeps a valid timezone preference', () => {
+  const zone = 'America/New_York';
+  const normalized = normalizeSettings({ baseTimeZone: zone });
+  assert.strictEqual(normalized.baseTimeZone, zone);
+});
+
+test('normalizeSettings skips invalid baseTimeZone in favor of valid aliases', async () => {
+  const zone = 'Europe/London';
+  const normalized = normalizeSettings({
+    baseTimeZone: 'Invalid/Zone',
+    timezone: zone,
+    sortMode: 'name'
+  });
+  await Promise.resolve();
+
+  assert.strictEqual(normalized.baseTimeZone, zone);
+  assert.strictEqual(normalized.sortMode, 'name');
+
+  const stored = await getStoredValue('settings', {});
+  assert.ok(!('baseTimeZone' in stored));
+  assert.strictEqual(stored.timezone, zone);
+});


### PR DESCRIPTION
## Summary
- validate stored base time zones before using them in the popup and purge invalid values from sync storage
- guard DOM lookups to avoid crashes when the popup module runs without a document
- add unit tests covering invalid, valid, and fallback timezone scenarios

## Testing
- node --test popup.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dc542c10cc8328b97aa974e5619be8