### PR TITLE
Add support link to PayPal from options page

### DIFF
--- a/assets/coffee.svg
+++ b/assets/coffee.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M5 7h12v6a5 5 0 0 1-5 5H10a5 5 0 0 1-5-5V7z" fill="#C08457"/>
+  <path d="M5 7h12v1H5z" fill="#925639"/>
+  <path d="M19 8h1a2 2 0 0 1 0 4h-1" stroke="#925639" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M7 19h8" stroke="#925639" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M9 4s-.5 1 .5 2-1 2-.5 3" stroke="#925639" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M13 4s-.5 1 .5 2-1 2-.5 3" stroke="#925639" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/options.css
+++ b/options.css
@@ -32,6 +32,10 @@ body {
 header {
   text-align: center;
   margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 header h1 {
@@ -42,6 +46,36 @@ main {
   display: flex;
   flex-direction: column;
   gap: 2rem;
+}
+
+.support-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--tt-color-accent);
+  background: var(--tt-color-card);
+  color: var(--tt-color-accent-strong);
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.support-link:hover,
+.support-link:focus-visible {
+  background: var(--tt-color-accent);
+  border-color: var(--tt-color-accent-strong);
+  color: var(--tt-color-accent-contrast);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px var(--tt-color-accent-soft);
+  outline: none;
+}
+
+.support-link__icon {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .card {
@@ -366,6 +400,17 @@ button:focus-visible {
   body {
     background: var(--tt-color-background);
     color: var(--tt-color-text);
+  }
+
+  .support-link {
+    background: var(--tt-color-card);
+    border-color: var(--tt-color-accent);
+    color: var(--tt-color-accent);
+  }
+
+  .support-link:hover,
+  .support-link:focus-visible {
+    box-shadow: none;
   }
 
   .card,

--- a/options.html
+++ b/options.html
@@ -10,6 +10,15 @@
     <header>
       <h1>Teams Time Options</h1>
       <p>Configure how times are displayed and manage your teammates.</p>
+      <a
+        class="support-link"
+        href="https://www.paypal.com/ncp/payment/3GD8QN5QPNG7A"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src="assets/coffee.svg" alt="" aria-hidden="true" class="support-link__icon" />
+        <span>Buy me a cup of coffee</span>
+      </a>
     </header>
     <main>
       <section aria-labelledby="hour-format-heading" class="card">


### PR DESCRIPTION
## Summary
- add a “Buy me a cup of coffee” PayPal link to the options page header
- style the support link so it matches the existing UI in light and dark themes
- include a dedicated coffee cup SVG icon for the new link

## Testing
- Manually loaded options.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68dd4c6b01508328be1fcc88e332a416