### PR TITLE
Add accessible tabbed navigation to Teams Time

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,66 +13,156 @@
     </header>
 
     <main class="page-content">
-      <section class="card card--current" aria-live="polite">
-        <h2>Current time</h2>
-        <p id="current-time" class="current-time" role="status"></p>
+      <div
+        id="main-tablist"
+        class="tablist"
+        role="tablist"
+        aria-label="Teams Time sections"
+      >
+        <button
+          type="button"
+          id="tab-overview"
+          role="tab"
+          aria-selected="true"
+          aria-controls="panel-overview"
+          tabindex="0"
+        >
+          Overview
+        </button>
+        <button
+          type="button"
+          id="tab-add"
+          role="tab"
+          aria-selected="false"
+          aria-controls="panel-add"
+          tabindex="-1"
+        >
+          Add teammate
+        </button>
+        <button
+          type="button"
+          id="tab-guide"
+          role="tab"
+          aria-selected="false"
+          aria-controls="panel-guide"
+          tabindex="-1"
+        >
+          Guide
+        </button>
+      </div>
+
+      <section
+        id="panel-overview"
+        class="tab-panel"
+        role="tabpanel"
+        aria-labelledby="tab-overview"
+      >
+        <div class="panel-grid">
+          <section class="card card--current" aria-live="polite">
+            <h2>Current time</h2>
+            <p id="current-time" class="current-time" role="status"></p>
+          </section>
+
+          <section class="card" aria-labelledby="roster-heading">
+            <div class="section-header">
+              <h2 id="roster-heading">Teammates</h2>
+              <p class="section-subtitle">
+                Remove someone when they no longer need tracking.
+              </p>
+            </div>
+            <div class="section-actions" aria-label="Teammate roster actions">
+              <button type="button" id="roster-export" title="Export teammate roster">
+                Export roster
+              </button>
+              <button type="button" id="roster-import" title="Import teammate roster">
+                Import roster
+              </button>
+              <input
+                type="file"
+                id="roster-import-input"
+                accept="application/json"
+                hidden
+                aria-hidden="true"
+              />
+            </div>
+            <p
+              id="roster-feedback"
+              class="status-message"
+              role="status"
+              aria-live="polite"
+            ></p>
+            <div id="roster-list" class="people-list" role="list" aria-live="polite"></div>
+          </section>
+        </div>
       </section>
 
-      <section class="card" aria-labelledby="add-teammate-heading">
-        <h2 id="add-teammate-heading">Add a teammate</h2>
-        <form id="teammate-form" autocomplete="off">
-          <div class="field">
-            <label for="teammate-name">Name</label>
-            <input type="text" id="teammate-name" name="name" required />
-          </div>
-          <div class="field">
-            <label for="teammate-note">Note</label>
-            <input
-              type="text"
-              id="teammate-note"
-              name="note"
-              placeholder="e.g., role, meeting focus"
-            />
-          </div>
-          <div class="field">
-            <label for="teammate-timezone">Time zone</label>
-            <input
-              type="text"
-              id="teammate-timezone"
-              name="timezone"
-              list="timezone-list"
-              placeholder="Search by city or zone"
-              required
-            />
-          </div>
-          <button type="submit" title="Add teammate">Add teammate</button>
-        </form>
-        <datalist id="timezone-list"></datalist>
+      <section
+        id="panel-add"
+        class="tab-panel"
+        role="tabpanel"
+        aria-labelledby="tab-add"
+        hidden
+      >
+        <div class="panel-grid">
+          <section class="card" aria-labelledby="add-teammate-heading">
+            <h2 id="add-teammate-heading">Add a teammate</h2>
+            <form id="teammate-form" autocomplete="off">
+              <div class="field">
+                <label for="teammate-name">Name</label>
+                <input type="text" id="teammate-name" name="name" required />
+              </div>
+              <div class="field">
+                <label for="teammate-note">Note</label>
+                <input
+                  type="text"
+                  id="teammate-note"
+                  name="note"
+                  placeholder="e.g., role, meeting focus"
+                />
+              </div>
+              <div class="field">
+                <label for="teammate-timezone">Time zone</label>
+                <input
+                  type="text"
+                  id="teammate-timezone"
+                  name="timezone"
+                  list="timezone-list"
+                  placeholder="Search by city or zone"
+                  required
+                />
+              </div>
+              <button type="submit" title="Add teammate">Add teammate</button>
+            </form>
+            <datalist id="timezone-list"></datalist>
+          </section>
+        </div>
       </section>
 
-      <section class="card" aria-labelledby="roster-heading">
-        <div class="section-header">
-          <h2 id="roster-heading">Teammates</h2>
-          <p class="section-subtitle">Remove someone when they no longer need tracking.</p>
+      <section
+        id="panel-guide"
+        class="tab-panel"
+        role="tabpanel"
+        aria-labelledby="tab-guide"
+        hidden
+      >
+        <div class="panel-grid">
+          <section class="card" aria-labelledby="guide-heading">
+            <h2 id="guide-heading">Using Teams Time</h2>
+            <p>
+              Monitor teammates across time zones, add new collaborators, and export
+              or import rosters when your lineup changes.
+            </p>
+            <ul>
+              <li>Use the Overview tab to keep track of the current time and roster.</li>
+              <li>Add teammates with notes and time zones from the Add teammate tab.</li>
+              <li>Import and export rosters to stay in sync with your team.</li>
+            </ul>
+            <p>
+              Everything runs locally in your browser so you can keep sensitive scheduling
+              details in your control.
+            </p>
+          </section>
         </div>
-        <div class="section-actions" aria-label="Teammate roster actions">
-          <button type="button" id="roster-export" title="Export teammate roster">Export roster</button>
-          <button type="button" id="roster-import" title="Import teammate roster">Import roster</button>
-          <input
-            type="file"
-            id="roster-import-input"
-            accept="application/json"
-            hidden
-            aria-hidden="true"
-          />
-        </div>
-        <p
-          id="roster-feedback"
-          class="status-message"
-          role="status"
-          aria-live="polite"
-        ></p>
-        <div id="roster-list" class="people-list" role="list" aria-live="polite"></div>
       </section>
     </main>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -55,6 +55,55 @@ body {
 .page-content {
   width: min(1100px, 100%);
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.tablist {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.tablist [role='tab'] {
+  border: 1px solid var(--tt-color-border);
+  border-radius: 0.75rem;
+  background: var(--tt-color-card-muted);
+  color: var(--tt-color-text);
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: none;
+  transform: none;
+}
+
+.tablist [role='tab'][aria-selected='true'] {
+  background: var(--tt-color-card);
+  border-color: var(--tt-color-accent);
+  color: var(--tt-color-accent-strong);
+  box-shadow: 0 6px 16px var(--tt-color-accent-soft);
+}
+
+.tablist [role='tab']:hover,
+.tablist [role='tab']:focus-visible {
+  background: var(--tt-color-card);
+  color: var(--tt-color-accent-strong);
+  box-shadow: 0 4px 12px var(--tt-color-accent-soft);
+  outline: none;
+  transform: none;
+}
+
+.tablist [role='tab']:focus-visible {
+  border-color: var(--tt-color-accent);
+}
+
+.tab-panel[hidden] {
+  display: none;
+}
+
+.panel-grid {
   display: grid;
   gap: 2rem;
 }
@@ -297,7 +346,7 @@ button:focus-visible {
 }
 
 @media (min-width: 720px) {
-  .page-content {
+  .panel-grid {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 2.25rem;
   }
@@ -310,6 +359,10 @@ button:focus-visible {
   }
 
   .page-content {
+    gap: 2.5rem;
+  }
+
+  .panel-grid {
     gap: 2.5rem;
   }
 


### PR DESCRIPTION
## Summary
- wrap the main page content in an accessible tablist with overview, add teammate, and guide panels
- style the new tab controls and panel grid layout while keeping existing card presentation intact
- manage tab activation in the bundle script, updating aria state, hidden panels, and limiting renders to the active view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddac5b9e34832898e583f54aa9955a