### PR TITLE
Relocate roster management to Add tab

### DIFF
--- a/public/app.bundle.js
+++ b/public/app.bundle.js
@@ -1463,8 +1463,14 @@
       renderRoster(now, baseTimeZone, sortMode, hour12, sortedPeople);
     }
 
-    if (overviewPeopleListElement && isElementInActivePanel(overviewPeopleListElement)) {
-      renderOverviewRoster(now, baseTimeZone, sortMode, hour12, sortedPeople);
+    if (overviewPeopleListElement) {
+      const overviewShouldRender =
+        isElementInActivePanel(overviewPeopleListElement) ||
+        isElementInActivePanel(rosterListElement);
+
+      if (overviewShouldRender) {
+        renderOverviewRoster(now, baseTimeZone, sortMode, hour12, sortedPeople);
+      }
     }
 
     if (timelineRowsElement) {

--- a/public/index.html
+++ b/public/index.html
@@ -80,37 +80,6 @@
               ></ul>
             </div>
           </section>
-
-          <section class="card" aria-labelledby="roster-heading">
-            <div class="section-header">
-              <h2 id="roster-heading">Teammates</h2>
-              <p class="section-subtitle">
-                Remove someone when they no longer need tracking.
-              </p>
-            </div>
-            <div class="section-actions" aria-label="Teammate roster actions">
-              <button type="button" id="roster-export" title="Export teammate roster">
-                Export roster
-              </button>
-              <button type="button" id="roster-import" title="Import teammate roster">
-                Import roster
-              </button>
-              <input
-                type="file"
-                id="roster-import-input"
-                accept="application/json"
-                hidden
-                aria-hidden="true"
-              />
-            </div>
-            <p
-              id="roster-feedback"
-              class="status-message"
-              role="status"
-              aria-live="polite"
-            ></p>
-            <div id="roster-list" class="people-list" role="list" aria-live="polite"></div>
-          </section>
         </div>
       </section>
 
@@ -152,6 +121,37 @@
               <button type="submit" title="Add teammate">Add teammate</button>
             </form>
             <datalist id="timezone-list"></datalist>
+          </section>
+
+          <section class="card" aria-labelledby="roster-heading">
+            <div class="section-header">
+              <h2 id="roster-heading">Teammates</h2>
+              <p class="section-subtitle">
+                Remove someone when they no longer need tracking.
+              </p>
+            </div>
+            <div class="section-actions" aria-label="Teammate roster actions">
+              <button type="button" id="roster-export" title="Export teammate roster">
+                Export roster
+              </button>
+              <button type="button" id="roster-import" title="Import teammate roster">
+                Import roster
+              </button>
+              <input
+                type="file"
+                id="roster-import-input"
+                accept="application/json"
+                hidden
+                aria-hidden="true"
+              />
+            </div>
+            <p
+              id="roster-feedback"
+              class="status-message"
+              role="status"
+              aria-live="polite"
+            ></p>
+            <div id="roster-list" class="people-list" role="list" aria-live="polite"></div>
           </section>
         </div>
       </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -106,6 +106,7 @@ body {
 .panel-grid {
   display: grid;
   gap: 2rem;
+  align-items: start;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- move the roster management card into the Add teammate tab alongside the form
- align panel grids so the add view handles differently sized cards without gaps
- update rendering logic so the overview list stays synced when managing the roster

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddb5ce056c832890c75589e7bd4fd4