### PR TITLE
Add support link to guide panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -206,6 +206,14 @@
               Everything runs locally in your browser so you can keep sensitive scheduling
               details in your control.
             </p>
+            <a
+              class="support-link"
+              href="https://www.paypal.com/ncp/payment/3GD8QN5QPNG7A"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Buy me a cup of coffee
+            </a>
           </section>
         </div>
       </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -119,6 +119,32 @@ body {
   gap: 1.25rem;
 }
 
+.support-link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--tt-color-accent);
+  background: var(--tt-color-card);
+  color: var(--tt-color-accent-strong);
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.support-link:hover,
+.support-link:focus-visible {
+  background: var(--tt-color-accent);
+  border-color: var(--tt-color-accent-strong);
+  color: var(--tt-color-accent-contrast);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px var(--tt-color-accent-soft);
+  outline: none;
+}
+
 .card > h2 {
   margin: 0;
   font-size: 1.25rem;


### PR DESCRIPTION
## Summary
- add a support link to the guide panel that matches the extension options label
- style the support link to align with the existing design

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de7559400c8328a5ffce689a8d526e