### PR TITLE
Add link to Chrome extension in guide

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -201,6 +201,16 @@
               <li>Use the Overview tab to keep track of the current time and roster.</li>
               <li>Add teammates with notes and time zones from the Add teammate tab.</li>
               <li>Import and export rosters to stay in sync with your team.</li>
+              <li>
+                <a
+                  href="https://chromewebstore.google.com/detail/mfpemimcnmmidbjdeokidbcjejjgheog?utm_source=item-share-cb"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Install the Teams Time Chrome extension
+                </a>
+                to keep these tools within reach.
+              </li>
             </ul>
             <p>
               Everything runs locally in your browser so you can keep sensitive scheduling


### PR DESCRIPTION
## Summary
- highlight the availability of the Teams Time Chrome extension in the guide tab
- add a direct link to the Chrome Web Store with proper attributes

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de75dd3934832897e744f62aae08b6